### PR TITLE
chore: fix line endings error

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,7 +8,7 @@ module.exports = {
   'extends': [
     'plugin:vue/vue3-essential',
     'eslint:recommended',
-    "@vue/typescript/recommended",
+    '@vue/typescript/recommended',
     '@vue/prettier',
     '@vue/prettier/@typescript-eslint'
   ],
@@ -20,6 +20,6 @@ module.exports = {
   rules: {
     'no-console': process.env.NODE_ENV === 'production' ? 'warn' : 'off',
     'no-debugger': process.env.NODE_ENV === 'production' ? 'warn' : 'off',
-	'prettier/prettier': ['error', { 'endOfLine': 'auto' }]  
+    'prettier/prettier': ['error', { 'endOfLine': 'auto' }]  
   }
 }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,7 +10,7 @@ module.exports = {
     'eslint:recommended',
     "@vue/typescript/recommended",
     '@vue/prettier',
-    "@vue/prettier/@typescript-eslint"
+    '@vue/prettier/@typescript-eslint'
   ],
 
   parserOptions: {
@@ -20,5 +20,6 @@ module.exports = {
   rules: {
     'no-console': process.env.NODE_ENV === 'production' ? 'warn' : 'off',
     'no-debugger': process.env.NODE_ENV === 'production' ? 'warn' : 'off',
+	'prettier/prettier': ['error', { 'endOfLine': 'auto' }]  
   }
 }


### PR DESCRIPTION
- Changed " to ' to be consistent with the rest of the file
- Added `'prettier/prettier': ['error', { 'endOfLine': 'auto' }]` rule which fixed the issue with eslint complaining about line endings and resulting in `npm run lint` making changes to every single file.